### PR TITLE
ci: cache docker layers using registry cache ref

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,5 +48,5 @@ jobs:
           tags: ghcr.io/emqx/${{ matrix.image[0] }}:${{ matrix.image[1] }}
           file: ${{ matrix.image[0] }}/Dockerfile
           context: ${{ matrix.image[0] }}
-          cache-from: type=gha
-          cache-to: type=gha
+          cache-from: type=registry,mode=max,ref=ghcr.io/emqx/${{ matrix.image[0] }}:build-cache
+          cache-to: type=registry,mode=max,ref=ghcr.io/emqx/${{ matrix.image[0] }}:build-cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,3 +48,5 @@ jobs:
           tags: ghcr.io/emqx/${{ matrix.image[0] }}:${{ matrix.image[1] }}
           file: ${{ matrix.image[0] }}/Dockerfile
           context: ${{ matrix.image[0] }}
+          cache-from: type=gha
+          cache-to: type=gha


### PR DESCRIPTION
Before (all 0 % cached, took 33 m 43 s, due to openldap):
https://github.com/emqx/docker-images/actions/runs/14603618021

After (ran all builds in 51 s, no changes):
https://github.com/emqx/docker-images/actions/runs/14604278134